### PR TITLE
Use `secrecy` crate for ICE password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ All user visible changes to this project will be documented in this file. This p
 ### BC Breaks
 
 - Bumped up [MSRV] to 1.81 because for `#[expect]` attribute usage. ([todo])
+- Changed return type of `AuthHandler::auth_handle` to [`SecretString`]. ([#3])
 
+[`SecretString`]: https://docs.rs/secrecy/0.10.3/secrecy/type.SecretString.html
 [todo]: /../../commit/todo
+[#3]: /../../pull/3
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ All user visible changes to this project will be documented in this file. This p
 ### BC Breaks
 
 - Bumped up [MSRV] to 1.81 because for `#[expect]` attribute usage. ([b0a1dfb6])
-- Changed return type of `AuthHandler::auth_handle` to [`SecretString`]. ([#3])
+- Changed return type of `AuthHandler::auth_handle()` to [`secrecy::SecretString`]. ([#3])
 
-[`SecretString`]: https://docs.rs/secrecy/0.10.3/secrecy/type.SecretString.html
-[b0a1dfb6]: /../../commit/b0a1dfb696b044d08fa720f2d3e52ed65a12e521
+[`secrecy::SecretString`]: https://docs.rs/secrecy/0.10.3/secrecy/type.SecretString.html
 [#3]: /../../pull/3
+[b0a1dfb6]: /../../commit/b0a1dfb696b044d08fa720f2d3e52ed65a12e521
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ All user visible changes to this project will be documented in this file. This p
 
 ### BC Breaks
 
-- Bumped up [MSRV] to 1.81 because for `#[expect]` attribute usage. ([todo])
+- Bumped up [MSRV] to 1.81 because for `#[expect]` attribute usage. ([b0a1dfb6])
 - Changed return type of `AuthHandler::auth_handle` to [`SecretString`]. ([#3])
 
 [`SecretString`]: https://docs.rs/secrecy/0.10.3/secrecy/type.SecretString.html
-[todo]: /../../commit/todo
+[b0a1dfb6]: /../../commit/b0a1dfb696b044d08fa720f2d3e52ed65a12e521
 [#3]: /../../pull/3
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ derive_more = { version = "1.0.0-beta.6", features = ["debug", "display", "error
 futures = "0.3.30"
 log = "0.4"
 rand = "0.8"
+secrecy = "0.10"
 stun_codec = "0.3.5"
 tokio = { version = "1.32", default-features = false, features = ["io-util", "macros", "net", "rt-multi-thread", "time"] }
 tokio-util = { version = "0.7.11", features = ["codec"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@ pub mod transport;
 use std::{net::SocketAddr, sync::Arc};
 
 use derive_more::{Display, Error as StdError, From};
+use secrecy::SecretString;
 
 #[cfg(test)]
 pub(crate) use self::allocation::Allocation;
@@ -190,7 +191,7 @@ pub trait AuthHandler {
         username: &str,
         realm: &str,
         src_addr: SocketAddr,
-    ) -> Result<Box<str>, Error>;
+    ) -> Result<SecretString, Error>;
 }
 
 impl<T: ?Sized + AuthHandler> AuthHandler for Arc<T> {
@@ -199,7 +200,7 @@ impl<T: ?Sized + AuthHandler> AuthHandler for Arc<T> {
         username: &str,
         realm: &str,
         src_addr: SocketAddr,
-    ) -> Result<Box<str>, Error> {
+    ) -> Result<SecretString, Error> {
         (**self).auth_handle(username, realm, src_addr)
     }
 }


### PR DESCRIPTION
## Synopsis

We need to use `secrecy::SecretString` instead of `Box<str>` for ICE password to improve security.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
