### PR TITLE
Fix transaction ID in STUN Binding response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-## [0.11.1] · 2025-06-13
+## [0.11.1] · unreleased
 [0.11.1]: https://github.com/instrumentisto/medea-turn-rs/tree/v0.11.1
 
 [Diff](https://github.com/instrumentisto/medea-turn-rs/compare/v0.11.0...v0.11.1)
 
 ### Fixed
 
-- Bad transaction ID in Binding response. ([#6])
+- Wrong transaction ID in binding `BINDING` response. ([#6])
 
 [#6]: https://github.com/instrumentisto/medea-turn-rs/pull/6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.11.1] · 2025-06-13
+[0.11.1]: https://github.com/instrumentisto/medea-turn-rs/tree/v0.11.1
+
+[Diff](https://github.com/instrumentisto/medea-turn-rs/compare/v0.11.0...v0.11.1)
+
+### Fixed
+
+- Bad transaction ID in Binding response. ([#6])
+
+[#6]: https://github.com/instrumentisto/medea-turn-rs/pull/6
+
+
+
+
 ## [0.11.0] · 2025-05-16
 [0.11.0]: https://github.com/instrumentisto/medea-turn-rs/tree/v0.11.0
 


### PR DESCRIPTION
## Synopsis

Binding response should have the same transaction ID as in Binding request


## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
