### PR TITLE
Rework relay port selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All user visible changes to this project will be documented in this file. This p
 ### BC Breaks
 
 - Removed `Error::NoSuchChannelBind` variant. ([#71])
-- `Allocator` fields are no longer public, use `Allocator::new()` constructor instead. ([#72])
+- `Allocator` fields are no longer public (use `Allocator::new()` constructor instead). ([#72])
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,18 @@ All user visible changes to this project will be documented in this file. This p
 ### BC Breaks
 
 - Removed `Error::NoSuchChannelBind` variant. ([#71])
+- `Allocator` fields are no longer public, use `Allocator::new()` constructor instead. ([#72])
 
 ### Added
 
 - `WrongCredentials` and `AllocationInactive` variants to `Error`. ([#71])
+- `PortsExhausted` and `NoEvenPortSupport` variants to `Error`. ([#71])
+- `Error::PortsExhausted` variant, returned when all ports in the relay range are in use. ([#72])
+- `Allocator::new()` constructor. ([#72])
+
+### Changed
+
+- Rework relay port selection algorithm to fix possibility of premature port exhaustion. ([#72])
 
 ### Fixed
 
@@ -27,6 +35,7 @@ All user visible changes to this project will be documented in this file. This p
 - `CreatePermission` request with no `XOR-PEER-ADDRESS` attributes now responds with 400 (Bad Request) error. ([#71])
 
 [#71]: https://github.com/instrumentisto/medea-turn-rs/pull/71
+[#72]: https://github.com/instrumentisto/medea-turn-rs/pull/72
 
 
 

--- a/src/allocation/channel_bind.rs
+++ b/src/allocation/channel_bind.rs
@@ -96,6 +96,7 @@ mod allocation_spec {
     use crate::{
         Allocation, Error, FiveTuple,
         attr::{ChannelNumber, Username},
+        relay,
         server::DEFAULT_ALLOC_LIFETIME,
     };
 
@@ -115,6 +116,7 @@ mod allocation_spec {
             DEFAULT_ALLOC_LIFETIME,
             Username::new(String::from("user")).unwrap(),
             None,
+            relay::PortGuard::dummy(),
         );
 
         let addr = SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 0);

--- a/src/allocation/manager.rs
+++ b/src/allocation/manager.rs
@@ -83,7 +83,6 @@ impl Manager {
         &mut self,
         five_tuple: FiveTuple,
         turn_socket: DynTransport,
-        requested_port: u16,
         lifetime: Duration,
         username: Username,
         use_ipv4: bool,
@@ -99,10 +98,8 @@ impl Manager {
             return Err(Error::DupeFiveTuple);
         }
 
-        let (relay_socket, relay_addr) = self
-            .relay_allocator
-            .allocate_conn(use_ipv4, requested_port)
-            .await?;
+        let (relay_socket, relay_addr, guard) =
+            self.relay_allocator.allocate_conn(use_ipv4).await?;
         let alloc = Allocation::new(
             turn_socket,
             relay_socket,
@@ -111,6 +108,7 @@ impl Manager {
             lifetime,
             username,
             self.alloc_close_notify.clone(),
+            guard,
         );
 
         drop(self.allocations.insert(five_tuple, alloc));
@@ -141,18 +139,6 @@ impl Manager {
         self.allocations
             .retain(|_, allocation| allocation.username.name() != username);
     }
-
-    /// Returns a random non-allocated UDP port.
-    ///
-    /// # Errors
-    ///
-    /// If new port fails to be allocated. See the [`Error`] for details.
-    pub(crate) async fn get_random_even_port(&self) -> Result<u16, Error> {
-        self.relay_allocator
-            .allocate_conn(true, 0)
-            .await
-            .map(|(_, addr)| addr.port())
-    }
 }
 
 #[cfg(test)]
@@ -181,13 +167,13 @@ mod spec {
     /// Creates a new [`Manager`] for testing purposes.
     fn create_manager() -> Manager {
         let config = Config {
-            relay_addr_generator: relay::Allocator {
-                relay_address: IpAddr::from([127, 0, 0, 1]),
-                min_port: 49152,
-                max_port: 65535,
-                max_retries: 10,
-                address: String::from("127.0.0.1"),
-            },
+            relay_addr_generator: relay::Allocator::new(
+                IpAddr::from([127, 0, 0, 1]),
+                String::from("127.0.0.1"),
+                49152,
+                65535,
+                1,
+            ),
             alloc_close_notify: None,
         };
         Manager::new(config)
@@ -238,7 +224,6 @@ mod spec {
             .create_allocation(
                 five_tuple,
                 Arc::new(turn_socket),
-                0,
                 DEFAULT_ALLOC_LIFETIME,
                 Username::new(String::from("user")).unwrap(),
                 true,
@@ -320,7 +305,6 @@ mod spec {
             .create_allocation(
                 five_tuple,
                 DynTransport::clone(&turn_socket),
-                0,
                 DEFAULT_ALLOC_LIFETIME,
                 Username::new(String::from("user")).unwrap(),
                 true,
@@ -332,7 +316,6 @@ mod spec {
             .create_allocation(
                 five_tuple,
                 DynTransport::clone(&turn_socket),
-                0,
                 DEFAULT_ALLOC_LIFETIME,
                 Username::new(String::from("user")).unwrap(),
                 true,
@@ -353,7 +336,6 @@ mod spec {
             .create_allocation(
                 five_tuple,
                 DynTransport::clone(&turn_socket),
-                0,
                 DEFAULT_ALLOC_LIFETIME,
                 Username::new(String::from("user")).unwrap(),
                 true,
@@ -389,7 +371,6 @@ mod spec {
                 .create_allocation(
                     five_tuple,
                     DynTransport::clone(&turn_socket),
-                    0,
                     lifetime,
                     Username::new(String::from("user")).unwrap(),
                     true,
@@ -437,7 +418,6 @@ mod spec {
             .create_allocation(
                 five_tuple1,
                 DynTransport::clone(&turn_socket),
-                0,
                 DEFAULT_ALLOC_LIFETIME,
                 Username::new(String::from("user")).unwrap(),
                 true,
@@ -448,7 +428,6 @@ mod spec {
             .create_allocation(
                 five_tuple2,
                 DynTransport::clone(&turn_socket),
-                0,
                 DEFAULT_ALLOC_LIFETIME,
                 Username::new(String::from("user")).unwrap(),
                 true,
@@ -459,7 +438,6 @@ mod spec {
             .create_allocation(
                 five_tuple3,
                 DynTransport::clone(&turn_socket),
-                0,
                 DEFAULT_ALLOC_LIFETIME,
                 Username::new(String::from("user2")).unwrap(),
                 true,

--- a/src/allocation/mod.rs
+++ b/src/allocation/mod.rs
@@ -36,6 +36,7 @@ use crate::{
     allocation::permission::PERMISSION_LIFETIME,
     attr::{Attribute, Data, Username, XorPeerAddress},
     chandata::ChannelData,
+    relay,
     server::INBOUND_MTU,
     transport,
 };
@@ -137,6 +138,10 @@ pub(crate) struct Allocation {
 
 impl Allocation {
     /// Creates a new [`Allocation`] out of the provided parameters.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "no such thing as too many arguments"
+    )]
     pub(crate) fn new(
         turn_socket: Arc<dyn Transport + Send + Sync>,
         relay_socket: Arc<UdpSocket>,
@@ -145,6 +150,7 @@ impl Allocation {
         lifetime: Duration,
         username: Username,
         alloc_close_notify: Option<mpsc::Sender<Info>>,
+        port_guard: relay::PortGuard,
     ) -> Self {
         let (refresh_tx, refresh_rx) = mpsc::channel(1);
 
@@ -160,7 +166,7 @@ impl Allocation {
             alloc_close_notify,
         };
 
-        this.spawn_relay_handler(refresh_rx, lifetime, turn_socket);
+        this.spawn_relay_handler(refresh_rx, lifetime, turn_socket, port_guard);
 
         this
     }
@@ -353,6 +359,7 @@ impl Allocation {
         mut refresh_rx: mpsc::Receiver<Duration>,
         lifetime: Duration,
         turn_socket: Arc<dyn Transport + Send + Sync>,
+        port_guard: relay::PortGuard,
     ) {
         let five_tuple = self.five_tuple;
         let relay_addr = self.relay_addr;
@@ -483,6 +490,7 @@ impl Allocation {
 
             drop(mem::take(&mut *channel_bindings.lock().await));
             drop(mem::take(&mut *permissions.lock().await));
+            drop(port_guard);
 
             log::trace!(
                 "`Allocation(five_tuple: {five_tuple})` stopped, stop \
@@ -521,6 +529,7 @@ mod spec {
     use super::{Allocation, FiveTuple};
     use crate::{
         attr::{ChannelNumber, PROTO_UDP, Username},
+        relay,
         server::DEFAULT_ALLOC_LIFETIME,
     };
 
@@ -547,6 +556,7 @@ mod spec {
             DEFAULT_ALLOC_LIFETIME,
             Username::new(String::from("user")).unwrap(),
             None,
+            relay::PortGuard::dummy(),
         );
 
         let addr1 = SocketAddr::from_str("127.0.0.1:3478").unwrap();
@@ -580,6 +590,7 @@ mod spec {
             DEFAULT_ALLOC_LIFETIME,
             Username::new(String::from("user")).unwrap(),
             None,
+            relay::PortGuard::dummy(),
         );
 
         let addr = SocketAddr::from_str("127.0.0.1:3478").unwrap();
@@ -602,6 +613,7 @@ mod spec {
             DEFAULT_ALLOC_LIFETIME,
             Username::new(String::from("user")).unwrap(),
             None,
+            relay::PortGuard::dummy(),
         );
 
         let addr = SocketAddr::from_str("127.0.0.1:3478").unwrap();
@@ -632,6 +644,7 @@ mod spec {
             DEFAULT_ALLOC_LIFETIME,
             Username::new(String::from("user")).unwrap(),
             None,
+            relay::PortGuard::dummy(),
         );
 
         let addr = SocketAddr::from_str("127.0.0.1:3478").unwrap();
@@ -661,6 +674,7 @@ mod spec {
             DEFAULT_ALLOC_LIFETIME,
             Username::new(String::from("user")).unwrap(),
             None,
+            relay::PortGuard::dummy(),
         );
 
         let addr = SocketAddr::from_str("127.0.0.1:3478").unwrap();

--- a/src/allocation/mod.rs
+++ b/src/allocation/mod.rs
@@ -138,10 +138,8 @@ pub(crate) struct Allocation {
 
 impl Allocation {
     /// Creates a new [`Allocation`] out of the provided parameters.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "no such thing as too many arguments"
-    )]
+    // TODO: Refactor to satisfy `clippy::too_many_arguments` lint.
+    #[expect(clippy::too_many_arguments, reason = "needs refactoring")]
     pub(crate) fn new(
         turn_socket: Arc<dyn Transport + Send + Sync>,
         relay_socket: Arc<UdpSocket>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,11 @@ pub enum Error {
     #[display("turn: max retries exceeded")]
     MaxRetriesExceeded,
 
+    /// All relay ports in the configured range are currently in use; no port
+    /// could be allocated.
+    #[display("turn: all relay ports exhausted")]
+    PortsExhausted,
+
     /// {eer address is part of a different address family than that of the
     /// relayed transport address of the allocation.
     #[display("error code 443: peer address family mismatch")]
@@ -301,6 +306,12 @@ pub enum Error {
     /// [1]: https://tools.ietf.org/html/rfc5766#section-14.8
     #[display("no support for DONT-FRAGMENT")]
     NoDontFragmentSupport,
+
+    /// [EVEN-PORT][1] attribute is not supported.
+    ///
+    /// [1]: https://datatracker.ietf.org/doc/html/rfc5766#section-14.6
+    #[display("no support for EVEN-PORT")]
+    NoEvenPortSupport,
 
     /// Allocation request cannot have both [RESERVATION-TOKEN][1] and
     /// [EVEN-PORT][2].

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -60,9 +60,9 @@ impl Allocator {
         &self,
         use_ipv4: bool,
     ) -> Result<(Arc<UdpSocket>, SocketAddr, PortGuard), Error> {
-        #[expect(
+        #[expect( // guards are not intended to be read, only exist
             clippy::collection_is_never_read,
-            reason = "not intended to be read"
+            reason = "guards are not intended to be read, only exist"
         )]
         let mut failed_guards = Vec::new();
 
@@ -90,11 +90,11 @@ impl Allocator {
                 Err(e) => {
                     log::warn!(
                         "Failed to bind relay socket on port {port}: {e}. \
-                        Attempt #{attempt}/{}",
+                         Attempt #{attempt}/{}",
                         self.max_retries,
                     );
                     // Keep failed ports out of the pool for the duration of
-                    // this call so we do not keep retrying the same busy port.
+                    // this call, to not keep retrying the same busy port.
                     failed_guards.push(guard);
                 }
             }
@@ -110,8 +110,9 @@ pub(crate) struct PortPool {
     /// Bit-vector of available ports, relative to `min_port`.
     bits: Arc<Mutex<Vec<u64>>>,
 
-    /// Lowest port number covered by this pool. Acts as an offset
-    /// when accessing bitvec.
+    /// Lowest port number covered by this [`PortPool`].
+    ///
+    /// Acts as an offset when accessing bitvec.
     min_port: u16,
 }
 
@@ -129,8 +130,8 @@ impl PortPool {
         Self { bits: Arc::new(Mutex::new(bits)), min_port }
     }
 
-    /// Claims and returns a random available port, or [`None`] if all ports
-    /// are currently in use.
+    /// Claims and returns a random available port, or [`None`] if all ports are
+    /// currently in use.
     fn acquire(&self) -> Option<u16> {
         #[expect(clippy::unwrap_used, reason = "locking")]
         let mut bits = self.bits.lock().unwrap();
@@ -150,7 +151,8 @@ impl PortPool {
             bits[word_idx] &= !(1u64 << bit);
             drop(bits);
 
-            // word_idx * 64 <= 65472 and bit <= 63, so neither try_from fails.
+            // `word_idx * 64 <= 65472` and `bit <= 63`, so neither `try_from`
+            // conversion fails.
             #[expect(clippy::unwrap_used, reason = "bounded by pool size")]
             let offset = u16::try_from(word_idx * 64).unwrap()
                 + u16::try_from(bit).unwrap();
@@ -174,7 +176,7 @@ impl PortPool {
     }
 }
 
-/// RAII guard that returns a relay port to its [`PortPool`] when dropped.
+/// Guard returning a relay port to its [`PortPool`] once dropped.
 ///
 /// Obtained via [`Allocator::allocate_conn()`].
 #[derive(Debug)]
@@ -193,19 +195,14 @@ impl Drop for PortGuard {
 }
 
 #[cfg(test)]
-mod test {
+mod port_pool_spec {
     use std::{
         collections::HashSet,
-        net::IpAddr,
         sync::{Arc, Mutex},
         thread,
-        time::Duration,
     };
 
-    use tokio::net::UdpSocket;
-
-    use super::{Allocator, PortGuard, PortPool};
-    use crate::Error;
+    use super::{PortGuard, PortPool};
 
     impl PortPool {
         /// Creates an empty pool (no ports available).
@@ -221,11 +218,13 @@ mod test {
     }
 
     #[test]
-    fn port_pool_acquire_exhausts_range() {
+    fn acquire_exhausts_range() {
         let pool = PortPool::new(20_000, 20_004);
         let mut seen = HashSet::new();
+
         for _ in 0..5 {
             let p = pool.acquire().expect("expected available port");
+
             assert!((20_000..=20_004).contains(&p));
             assert!(seen.insert(p), "duplicate port {p}");
         }
@@ -233,43 +232,53 @@ mod test {
     }
 
     #[test]
-    fn port_pool_release_allows_reacquire() {
+    fn release_allows_reacquire() {
         let pool = PortPool::new(30_000, 30_000);
+
         assert_eq!(pool.acquire(), Some(30_000));
         assert!(pool.acquire().is_none());
+
         pool.release(30_000);
+
         assert_eq!(pool.acquire(), Some(30_000));
         assert!(pool.acquire().is_none());
     }
 
     #[tokio::test]
-    async fn pool_single_port() {
+    async fn single_port() {
         let pool = PortPool::new(1, 1);
+
         assert_eq!(pool.acquire(), Some(1));
         assert_eq!(pool.acquire(), None);
+
         pool.release(1);
+
         assert_eq!(pool.acquire(), Some(1));
     }
 
     #[test]
-    fn port_pool_single_port_boundary_max() {
+    fn single_port_boundary_max() {
         let pool = PortPool::new(u16::MAX, u16::MAX);
+
         assert_eq!(pool.acquire(), Some(u16::MAX));
         assert!(pool.acquire().is_none());
+
         pool.release(u16::MAX);
+
         assert_eq!(pool.acquire(), Some(u16::MAX));
     }
 
     #[test]
     #[should_panic(expected = "min_port must be <= max_port")]
-    fn port_pool_new_panics_when_min_greater_than_max() {
+    fn new_panics_when_min_greater_than_max() {
         drop(PortPool::new(100, 99));
     }
 
     #[test]
-    fn port_pool_acquired_ports_stay_in_range() {
+    fn acquired_ports_stay_in_range() {
         let pool = PortPool::new(1000, 1063);
         let mut seen = HashSet::new();
+
         while let Some(p) = pool.acquire() {
             assert!((1000..=1063).contains(&p), "port {p} out of range");
             assert!(seen.insert(p), "duplicate port {p}");
@@ -278,12 +287,13 @@ mod test {
     }
 
     #[test]
-    fn port_pool_multiple_release_and_reacquire() {
+    fn multiple_release_and_reacquire() {
         let pool = PortPool::new(5000, 5002);
 
         let p0 = pool.acquire().unwrap();
         let p1 = pool.acquire().unwrap();
         let p2 = pool.acquire().unwrap();
+
         assert!(pool.acquire().is_none());
 
         pool.release(p1);
@@ -294,24 +304,13 @@ mod test {
         for _ in 0..3 {
             reclaimed.insert(pool.acquire().expect("port should be available"));
         }
+
         assert_eq!(reclaimed, HashSet::from([p0, p1, p2]));
         assert!(pool.acquire().is_none());
     }
 
     #[test]
-    fn port_guard_releases_on_drop() {
-        let pool = PortPool::new(7000, 7000);
-        assert_eq!(pool.acquire(), Some(7000));
-        assert!(pool.acquire().is_none());
-
-        let guard = PortGuard { port: 7000, pool: pool.clone() };
-        drop(guard);
-
-        assert_eq!(pool.acquire(), Some(7000));
-    }
-
-    #[test]
-    fn port_pool_concurrent_acquire_no_duplicates() {
+    fn concurrent_acquire_no_duplicates() {
         let pool = Arc::new(PortPool::new(10_000, 10_063));
         let acquired: Arc<Mutex<HashSet<u16>>> =
             Arc::new(Mutex::new(HashSet::new()));
@@ -324,6 +323,7 @@ mod test {
                     // Each thread grabs ports until none are left.
                     while let Some(p) = pool.acquire() {
                         let mut set = acquired.lock().unwrap();
+
                         assert!(set.insert(p), "duplicate port {p}");
                     }
                 })
@@ -336,9 +336,37 @@ mod test {
 
         assert_eq!(acquired.lock().unwrap().len(), 64);
     }
+}
+
+#[cfg(test)]
+mod port_guard_spec {
+    use super::{PortGuard, PortPool};
+
+    #[test]
+    fn releases_on_drop() {
+        let pool = PortPool::new(7000, 7000);
+
+        assert_eq!(pool.acquire(), Some(7000));
+        assert!(pool.acquire().is_none());
+
+        let guard = PortGuard { port: 7000, pool: pool.clone() };
+        drop(guard);
+
+        assert_eq!(pool.acquire(), Some(7000));
+    }
+}
+
+#[cfg(test)]
+mod allocator_spec {
+    use std::{net::IpAddr, thread, time::Duration};
+
+    use tokio::net::UdpSocket;
+
+    use super::Allocator;
+    use crate::Error;
 
     #[tokio::test]
-    async fn allocator_skips_busy_ports() {
+    async fn skips_busy_ports() {
         let busy = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let busy_port = busy.local_addr().unwrap().port();
         let allocator = Allocator::new(
@@ -357,7 +385,7 @@ mod test {
 
         assert_eq!(
             allocator.allocate_conn(true).await.unwrap_err(),
-            Error::PortsExhausted
+            Error::PortsExhausted,
         );
     }
 
@@ -384,19 +412,23 @@ mod test {
         // No more ports at this point.
         assert_eq!(
             allocator.allocate_conn(true).await.unwrap_err(),
-            Error::PortsExhausted
+            Error::PortsExhausted,
         );
 
         ports.sort();
+
         assert_eq!(ports, [49152, 49153, 49154]);
 
         // Now drop guard but not socket.
         drop(guard1);
+
         // Socket is alive, so allocation attempt fails.
-        assert!(allocator.allocate_conn(true).await.is_err(),);
+        assert!(allocator.allocate_conn(true).await.is_err());
+
         // Drop socket and wait a bit for system to properly kill it.
         drop(socket1);
         thread::sleep(Duration::from_millis(500));
+
         // It can be properly reused now.
         assert_eq!(allocator.allocate_conn(true).await.unwrap().2.port, 49152);
     }

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -2,7 +2,7 @@
 
 use std::{
     net::{IpAddr, SocketAddr},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use tokio::net::UdpSocket;
@@ -15,74 +15,389 @@ use crate::{Error, transport};
 #[derive(Clone, Debug)]
 pub struct Allocator {
     /// [`IpAddr`] returned to the user when a relay is created.
-    pub relay_address: IpAddr,
+    relay_address: IpAddr,
 
-    /// Minimum (inclusive) port to allocate.
-    pub min_port: u16,
-
-    /// Maximum (inclusive) port to allocate.
-    pub max_port: u16,
+    /// Address passed when binding relay sockets.
+    address: String,
 
     /// Amount of tries to allocate a random port in the allowed range.
-    pub max_retries: u16,
+    max_retries: u16,
 
-    /// Address passed when creating a relay.
-    pub address: String,
+    /// Available ports.
+    pool: PortPool,
 }
 
 impl Allocator {
-    /// Allocates a new relay connection.
+    /// Creates a new [`Allocator`].
+    #[must_use]
+    pub fn new(
+        relay_address: IpAddr,
+        address: String,
+        min_port: u16,
+        max_port: u16,
+        max_retries: u16,
+    ) -> Self {
+        Self {
+            relay_address,
+            address,
+            max_retries,
+            pool: PortPool::new(min_port, max_port),
+        }
+    }
+
+    /// Picks a random available port from the pool, binds a [`UdpSocket`] to
+    /// it, and returns the socket, its relay [`SocketAddr`], and a
+    /// [`PortGuard`].
+    ///
     ///
     /// # Errors
     ///
-    /// - With an [`Error::MaxRetriesExceeded`] if the requested port is `0` and
-    ///   failed to find a free port in the specified [`max_retries`].
-    /// - With an [`Error::Transport`] if failed to bind to the specified port.
-    ///
-    /// [`max_retries`]: Allocator::max_retries
-    pub async fn allocate_conn(
+    /// - [`Error::PortsExhausted`] if no port is available in the pool.
+    /// - [`Error::MaxRetriesExceeded`] if the configured attempt budget is
+    ///   exhausted before finding a bindable port.
+    /// - [`Error::Transport`] if a non-bind transport error occurred.
+    pub(crate) async fn allocate_conn(
         &self,
         use_ipv4: bool,
-        requested_port: u16,
-    ) -> Result<(Arc<UdpSocket>, SocketAddr), Error> {
-        let max_retries =
-            if self.max_retries == 0 { 10 } else { self.max_retries };
+    ) -> Result<(Arc<UdpSocket>, SocketAddr, PortGuard), Error> {
+        #[expect(
+            clippy::collection_is_never_read,
+            reason = "not intended to be read"
+        )]
+        let mut failed_guards = Vec::new();
 
-        if requested_port == 0 {
-            for _ in 0..max_retries {
-                let port = self.min_port
-                    + rand::random::<u16>()
-                        % (self.max_port - self.min_port + 1);
-                let addr = transport::lookup_host(
-                    use_ipv4,
-                    &format!("{}:{port}", self.address),
-                )
-                .await?;
-                let Ok(conn) = UdpSocket::bind(addr).await else {
-                    continue;
-                };
+        // Start from `0` to always make at least one attempt.
+        for attempt in 0..=self.max_retries {
+            let port = self.pool.acquire().ok_or(Error::PortsExhausted)?;
 
-                let mut relay_addr =
-                    conn.local_addr().map_err(transport::Error::from)?;
-                relay_addr.set_ip(self.relay_address);
-                return Ok((Arc::new(conn), relay_addr));
-            }
+            let guard = PortGuard { port, pool: self.pool.clone() };
 
-            Err(Error::MaxRetriesExceeded)
-        } else {
             let addr = transport::lookup_host(
                 use_ipv4,
-                &format!("{}:{requested_port}", self.address),
+                &format!("{}:{port}", self.address),
             )
             .await?;
-            let conn = Arc::new(
-                UdpSocket::bind(addr).await.map_err(transport::Error::from)?,
-            );
-            let mut relay_addr =
-                conn.local_addr().map_err(transport::Error::from)?;
-            relay_addr.set_ip(self.relay_address);
 
-            Ok((conn, relay_addr))
+            match UdpSocket::bind(addr).await {
+                Ok(socket) => {
+                    let socket = Arc::new(socket);
+                    let mut relay_addr =
+                        socket.local_addr().map_err(transport::Error::from)?;
+                    relay_addr.set_ip(self.relay_address);
+
+                    return Ok((socket, relay_addr, guard));
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Failed to bind relay socket on port {port}: {e}. \
+                        Attempt #{attempt}/{}",
+                        self.max_retries,
+                    );
+                    // Keep failed ports out of the pool for the duration of
+                    // this call so we do not keep retrying the same busy port.
+                    failed_guards.push(guard);
+                }
+            }
         }
+
+        Err(Error::MaxRetriesExceeded)
+    }
+}
+
+/// Shared pool of available relay ports.
+#[derive(Clone, Debug)]
+pub(crate) struct PortPool {
+    /// Bit-vector of available ports, relative to `min_port`.
+    bits: Arc<Mutex<Vec<u64>>>,
+
+    /// Lowest port number covered by this pool. Acts as an offset
+    /// when accessing bitvec.
+    min_port: u16,
+}
+
+impl PortPool {
+    /// Creates a pool with every port in `min_port..=max_port` available.
+    fn new(min_port: u16, max_port: u16) -> Self {
+        assert!(min_port <= max_port, "min_port must be <= max_port");
+
+        let range = usize::from(max_port) - usize::from(min_port) + 1;
+        let num_words = range.div_ceil(64);
+        let mut bits = vec![0u64; num_words];
+        for i in 0..range {
+            bits[i / 64] |= 1u64 << (i % 64);
+        }
+        Self { bits: Arc::new(Mutex::new(bits)), min_port }
+    }
+
+    /// Claims and returns a random available port, or [`None`] if all ports
+    /// are currently in use.
+    fn acquire(&self) -> Option<u16> {
+        #[expect(clippy::unwrap_used, reason = "locking")]
+        let mut bits = self.bits.lock().unwrap();
+        let len = bits.len();
+        if len == 0 {
+            return None;
+        }
+        let start = usize::from(rand::random::<u16>()) % len;
+        for i in 0..len {
+            let word_idx = (start + i) % len;
+            let word = bits[word_idx];
+            if word == 0 {
+                continue;
+            }
+
+            let bit = word.trailing_zeros();
+            bits[word_idx] &= !(1u64 << bit);
+            drop(bits);
+
+            // word_idx * 64 <= 65472 and bit <= 63, so neither try_from fails.
+            #[expect(clippy::unwrap_used, reason = "bounded by pool size")]
+            let offset = u16::try_from(word_idx * 64).unwrap()
+                + u16::try_from(bit).unwrap();
+
+            let port = self.min_port + offset;
+
+            return Some(port);
+        }
+        None
+    }
+
+    /// Returns a previously acquired port back to the pool.
+    pub(crate) fn release(&self, port: u16) {
+        let port = usize::from(port);
+        let base = usize::from(self.min_port);
+        let Some(i) = port.checked_sub(base) else { return };
+        #[expect(clippy::unwrap_used, reason = "locking")]
+        if let Some(word) = self.bits.lock().unwrap().get_mut(i / 64) {
+            *word |= 1u64 << (i % 64);
+        }
+    }
+}
+
+/// RAII guard that returns a relay port to its [`PortPool`] when dropped.
+///
+/// Obtained via [`Allocator::allocate_conn()`].
+#[derive(Debug)]
+pub(crate) struct PortGuard {
+    /// Port being held.
+    port: u16,
+
+    /// Pool this port belongs to.
+    pool: PortPool,
+}
+
+impl Drop for PortGuard {
+    fn drop(&mut self) {
+        self.pool.release(self.port);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        collections::HashSet,
+        net::IpAddr,
+        sync::{Arc, Mutex},
+        thread,
+        time::Duration,
+    };
+
+    use tokio::net::UdpSocket;
+
+    use super::{Allocator, PortGuard, PortPool};
+    use crate::Error;
+
+    impl PortPool {
+        /// Creates an empty pool (no ports available).
+        pub(crate) fn dummy() -> Self {
+            Self { bits: Arc::new(Mutex::new(vec![])), min_port: 0 }
+        }
+    }
+
+    impl PortGuard {
+        pub(crate) fn dummy() -> Self {
+            Self { port: 0, pool: PortPool::dummy() }
+        }
+    }
+
+    #[test]
+    fn port_pool_acquire_exhausts_range() {
+        let pool = PortPool::new(20_000, 20_004);
+        let mut seen = HashSet::new();
+        for _ in 0..5 {
+            let p = pool.acquire().expect("expected available port");
+            assert!((20_000..=20_004).contains(&p));
+            assert!(seen.insert(p), "duplicate port {p}");
+        }
+        assert!(pool.acquire().is_none());
+    }
+
+    #[test]
+    fn port_pool_release_allows_reacquire() {
+        let pool = PortPool::new(30_000, 30_000);
+        assert_eq!(pool.acquire(), Some(30_000));
+        assert!(pool.acquire().is_none());
+        pool.release(30_000);
+        assert_eq!(pool.acquire(), Some(30_000));
+        assert!(pool.acquire().is_none());
+    }
+
+    #[tokio::test]
+    async fn pool_single_port() {
+        let pool = PortPool::new(1, 1);
+        assert_eq!(pool.acquire(), Some(1));
+        assert_eq!(pool.acquire(), None);
+        pool.release(1);
+        assert_eq!(pool.acquire(), Some(1));
+    }
+
+    #[test]
+    fn port_pool_single_port_boundary_max() {
+        let pool = PortPool::new(u16::MAX, u16::MAX);
+        assert_eq!(pool.acquire(), Some(u16::MAX));
+        assert!(pool.acquire().is_none());
+        pool.release(u16::MAX);
+        assert_eq!(pool.acquire(), Some(u16::MAX));
+    }
+
+    #[test]
+    #[should_panic(expected = "min_port must be <= max_port")]
+    fn port_pool_new_panics_when_min_greater_than_max() {
+        drop(PortPool::new(100, 99));
+    }
+
+    #[test]
+    fn port_pool_acquired_ports_stay_in_range() {
+        let pool = PortPool::new(1000, 1063);
+        let mut seen = HashSet::new();
+        while let Some(p) = pool.acquire() {
+            assert!((1000..=1063).contains(&p), "port {p} out of range");
+            assert!(seen.insert(p), "duplicate port {p}");
+        }
+        assert_eq!(seen.len(), 64);
+    }
+
+    #[test]
+    fn port_pool_multiple_release_and_reacquire() {
+        let pool = PortPool::new(5000, 5002);
+
+        let p0 = pool.acquire().unwrap();
+        let p1 = pool.acquire().unwrap();
+        let p2 = pool.acquire().unwrap();
+        assert!(pool.acquire().is_none());
+
+        pool.release(p1);
+        pool.release(p0);
+        pool.release(p2);
+
+        let mut reclaimed = HashSet::new();
+        for _ in 0..3 {
+            reclaimed.insert(pool.acquire().expect("port should be available"));
+        }
+        assert_eq!(reclaimed, HashSet::from([p0, p1, p2]));
+        assert!(pool.acquire().is_none());
+    }
+
+    #[test]
+    fn port_guard_releases_on_drop() {
+        let pool = PortPool::new(7000, 7000);
+        assert_eq!(pool.acquire(), Some(7000));
+        assert!(pool.acquire().is_none());
+
+        let guard = PortGuard { port: 7000, pool: pool.clone() };
+        drop(guard);
+
+        assert_eq!(pool.acquire(), Some(7000));
+    }
+
+    #[test]
+    fn port_pool_concurrent_acquire_no_duplicates() {
+        let pool = Arc::new(PortPool::new(10_000, 10_063));
+        let acquired: Arc<Mutex<HashSet<u16>>> =
+            Arc::new(Mutex::new(HashSet::new()));
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let pool = Arc::clone(&pool);
+                let acquired = Arc::clone(&acquired);
+                thread::spawn(move || {
+                    // Each thread grabs ports until none are left.
+                    while let Some(p) = pool.acquire() {
+                        let mut set = acquired.lock().unwrap();
+                        assert!(set.insert(p), "duplicate port {p}");
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
+
+        assert_eq!(acquired.lock().unwrap().len(), 64);
+    }
+
+    #[tokio::test]
+    async fn allocator_skips_busy_ports() {
+        let busy = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let busy_port = busy.local_addr().unwrap().port();
+        let allocator = Allocator::new(
+            IpAddr::from([127, 0, 0, 1]),
+            String::from("127.0.0.1"),
+            busy_port,
+            busy_port + 1,
+            2,
+        );
+
+        let (_socket, relay_addr, _guard) =
+            allocator.allocate_conn(true).await.unwrap();
+
+        assert_eq!(relay_addr.ip(), IpAddr::from([127, 0, 0, 1]));
+        assert_eq!(relay_addr.port(), busy_port + 1);
+
+        assert_eq!(
+            allocator.allocate_conn(true).await.unwrap_err(),
+            Error::PortsExhausted
+        );
+    }
+
+    #[tokio::test]
+    async fn normal_usage() {
+        let allocator = Allocator::new(
+            IpAddr::from([127, 0, 0, 1]),
+            String::from("127.0.0.1"),
+            49152,
+            49154,
+            1,
+        );
+        let mut ports = Vec::new();
+        let (socket1, _relay_addr1, guard1) =
+            allocator.allocate_conn(true).await.unwrap();
+        ports.push(guard1.port);
+        let (_socket2, _relay_addr2, guard2) =
+            allocator.allocate_conn(true).await.unwrap();
+        ports.push(guard2.port);
+        let (_socket3, _relay_addr3, guard3) =
+            allocator.allocate_conn(true).await.unwrap();
+        ports.push(guard3.port);
+
+        // No more ports at this point.
+        assert_eq!(
+            allocator.allocate_conn(true).await.unwrap_err(),
+            Error::PortsExhausted
+        );
+
+        ports.sort();
+        assert_eq!(ports, [49152, 49153, 49154]);
+
+        // Now drop guard but not socket.
+        drop(guard1);
+        // Socket is alive, so allocation attempt fails.
+        assert!(allocator.allocate_conn(true).await.is_err(),);
+        // Drop socket and wait a bit for system to properly kill it.
+        drop(socket1);
+        thread::sleep(Duration::from_millis(500));
+        // It can be properly reused now.
+        assert_eq!(allocator.allocate_conn(true).await.unwrap().2.port, 49152);
     }
 }

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -201,7 +201,6 @@ async fn handle_allocate_request(
     //    unless the client and server agree to use another mechanism through
     //    some procedure outside the scope of this document.
 
-    let mut requested_port = 0;
     let mut use_ipv4 = true;
 
     // 2. The server checks if the 5-tuple is currently in use by an existing
@@ -329,26 +328,12 @@ async fn handle_allocate_request(
     //    server cannot satisfy the request, then the server rejects the request
     //    with a 508 (Insufficient Capacity) error.
     if even_port.is_some() {
-        let mut random_port = 1;
+        // No reason to support EVEN-PORT, it's pretty much obsolete and not
+        // used by libwebrtc.
+        respond_with_err(&msg, InsufficientCapacity, conn, five_tuple.src_addr)
+            .await;
 
-        while random_port % 2 != 0 {
-            random_port = match allocs.get_random_even_port().await {
-                Ok(port) => port,
-                Err(err) => {
-                    respond_with_err(
-                        &msg,
-                        InsufficientCapacity,
-                        conn,
-                        five_tuple.src_addr,
-                    )
-                    .await;
-
-                    return Err(err);
-                }
-            };
-        }
-
-        requested_port = random_port;
+        return Err(Error::NoEvenPortSupport);
     }
 
     // If the request contains a `LIFETIME` attribute, then the server computes
@@ -367,7 +352,6 @@ async fn handle_allocate_request(
         .create_allocation(
             five_tuple,
             Arc::clone(conn),
-            requested_port,
             lifetime,
             creds.uname.clone(),
             use_ipv4,
@@ -1064,13 +1048,13 @@ mod handle_spec {
 
         let mut allocation_manager =
             allocation::Manager::new(allocation::ManagerConfig {
-                relay_addr_generator: relay::Allocator {
-                    relay_address: IpAddr::from([127, 0, 0, 1]),
-                    min_port: 49152,
-                    max_port: 65535,
-                    max_retries: 10,
-                    address: String::from("127.0.0.1"),
-                },
+                relay_addr_generator: relay::Allocator::new(
+                    IpAddr::from([127, 0, 0, 1]),
+                    String::from("127.0.0.1"),
+                    49152,
+                    65535,
+                    1,
+                ),
                 alloc_close_notify: None,
             });
 
@@ -1089,7 +1073,6 @@ mod handle_spec {
             .create_allocation(
                 five_tuple,
                 Arc::clone(&conn),
-                0,
                 Duration::from_secs(3600),
                 Username::new(STATIC_KEY.to_owned()).unwrap(),
                 true,
@@ -1119,13 +1102,13 @@ mod handle_spec {
 
         let mut turn = Some(TurnCtx {
             conf: TurnConfig {
-                relay_addr_generator: Allocator {
-                    relay_address: IpAddr::from([127, 0, 0, 1]),
-                    min_port: 0,
-                    max_port: 0,
-                    max_retries: 0,
-                    address: "".to_string(),
-                },
+                relay_addr_generator: Allocator::new(
+                    IpAddr::from([127, 0, 0, 1]),
+                    String::new(),
+                    0,
+                    0,
+                    1,
+                ),
                 realm: STATIC_KEY.to_owned(),
                 auth_handler: Arc::new(TestAuthHandler {}),
                 channel_bind_lifetime: Duration::from_secs(60),


### PR DESCRIPTION
## Synopsis

Relay allocation could prematurely fail with port exhaustion when a busy port was retried repeatedly instead of moving on to other still-available ports in the configured relay range.


## Solution

Rework relay port selection to keep track of used/unused ports.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
